### PR TITLE
[EvoGarden] switch to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: Go CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 'stable'
+      - name: Format
+        run: |
+          files=$(gofmt -l $(git ls-files '*.go'))
+          if [ -n "$files" ]; then
+            echo "Go files not formatted:" && echo "$files" && exit 1
+          fi
+      - name: Lint
+        run: go vet ./...
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
## Summary
- replace custom dependency update workflow with Dependabot

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684523aed400832fa93e2a28df560494