### PR TITLE
[EvoGarden] Monitor GitHub Action updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary
- update Dependabot configuration to track GitHub Action updates

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845471f1e2c832fa3a51159aef56dfd