### PR TITLE
[EvoGarden] Add simulation workflow

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -1,0 +1,22 @@
+name: Run Simulation
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  run-simulation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+      - name: Run simulation
+        run: |
+          go run ./cmd/evogarden | tee simulation.log
+      - name: Upload simulation log
+        uses: actions/upload-artifact@v4
+        with:
+          name: simulation-log
+          path: simulation.log

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -14,7 +14,7 @@ jobs:
           go-version: 'stable'
       - name: Run simulation
         run: |
-          go run ./cmd/evogarden | tee simulation.log
+          go run ./cmd/evolve | tee simulation.log
       - name: Upload simulation log
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- add a Simulation workflow that runs `go run ./cmd/evogarden`
- allow manual or PR-based runs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684556df0bd4832fa03e029eca5c8e07